### PR TITLE
Fix zone unsuspend & bump minor version

### DIFF
--- a/hydrawiser/__init__.py
+++ b/hydrawiser/__init__.py
@@ -6,6 +6,6 @@ and Pro-HC sprinkler controllers.
 """
 
 __author__ = 'David Ryan'
-__version__ = '0.2'
+__version__ = '0.2.1'
 __copyright__ = 'Copyright (c) 2020 David Ryan'
 __license__ = 'MIT'

--- a/hydrawiser/helpers.py
+++ b/hydrawiser/helpers.py
@@ -105,6 +105,9 @@ def set_zones(token, action, relay=None, time=None):
     if action in ['run', 'runall', 'suspend', 'suspendall']:
         if time is None:
             return None
+        elif time <= 0:
+            custom_cmd = ''
+            period_cmd = '&period_id=0'
         else:
             custom_cmd = '&custom={}'.format(time)
             period_cmd = '&period_id=999'

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(
     name='Hydrawiser',
     packages=['hydrawiser'],
-    version='0.2',
+    version='0.2.1',
     description='A Python library to communicate with Hunter ' +
                 'Wi-Fi irrigation controllers ' +
                 '(https://www.hunter.com) that support the ' +


### PR DESCRIPTION
Unsuspend does not work right now, because the v1.4 API does not like the period_id=999 when issuing an unsuspend.

I have tested this change locally, and it works just fine. 

This is tied to:
https://github.com/home-assistant/core/issues/68018
