### PR TITLE
Raise exception in case of API rate limit reached

### DIFF
--- a/hydrawiser/core.py
+++ b/hydrawiser/core.py
@@ -9,6 +9,7 @@ attributes available.
 
 import time
 from hydrawiser.helpers import customer_details, status_schedule, set_zones
+from requests.exceptions import ConnectTimeout, HTTPError
 
 
 class Hydrawiser():
@@ -48,8 +49,13 @@ class Hydrawiser():
         """
 
         # Read the controller information.
-        self.controller_info = customer_details(self._user_token)
-        self.controller_status = status_schedule(self._user_token)
+        try:
+            self.controller_info = customer_details(self._user_token)
+            self.controller_status = status_schedule(self._user_token)
+        except HTTPError as err:
+            # Handling the newly introduced rate limit
+            if err.response.status_code == 429:
+                raise HTTPError(err.response.text)
 
         if self.controller_info is None or self.controller_status is None:
             return False

--- a/hydrawiser/helpers.py
+++ b/hydrawiser/helpers.py
@@ -19,12 +19,13 @@ def status_schedule(token):
     :rtype: string or None
     """
 
-    url = 'https://app.hydrawise.com/api/v1/statusschedule.php'
+    url = 'https://api.hydrawise.com/api/v1/statusschedule.php'
 
     payload = {
         'api_key': token}
 
     get_response = requests.get(url, params=payload, timeout=REQUESTS_TIMEOUT)
+    get_response.raise_for_status()
 
     if get_response.status_code == 200 and \
        'error_msg' not in get_response.json():
@@ -45,13 +46,14 @@ def customer_details(token):
     :rtype: string or None.
     """
 
-    url = 'https://app.hydrawise.com/api/v1/customerdetails.php'
+    url = 'https://api.hydrawise.com/api/v1/customerdetails.php'
 
     payload = {
         'api_key': token,
         'type': 'controllers'}
 
     get_response = requests.get(url, params=payload, timeout=REQUESTS_TIMEOUT)
+    get_response.raise_for_status()
 
     if get_response.status_code == 200 and \
        'error_msg' not in get_response.json():
@@ -116,7 +118,7 @@ def set_zones(token, action, relay=None, time=None):
     if action in ['stop', 'run', 'suspend'] and relay is None:
         return None
 
-    get_response = requests.get('https://app.hydrawise.com/api/v1/'
+    get_response = requests.get('https://api.hydrawise.com/api/v1/'
                                 'setzone.php?'
                                 '&api_key={}'
                                 '&action={}{}{}{}'

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -10,7 +10,7 @@ def test_status_schedule():
     with requests_mock.Mocker() as m:
 
         # Test a valid api_key.
-        m.get('https://app.hydrawise.com/api/v1/statusschedule.php?'
+        m.get('https://api.hydrawise.com/api/v1/statusschedule.php?'
               'api_key={}'
               .format(GOOD_API_KEY),
               text=good_string)
@@ -19,7 +19,7 @@ def test_status_schedule():
         assert return_value is not None
 
         # Test an invalid api_key.
-        m.get('https://app.hydrawise.com/api/v1/statusschedule.php?'
+        m.get('https://api.hydrawise.com/api/v1/statusschedule.php?'
               'api_key={}'
               .format(BAD_API_KEY),
               text=unauthorized_string)
@@ -33,7 +33,7 @@ def test_customer_details():
     with requests_mock.Mocker() as m:
 
         # Test a valid api_key.
-        m.get('https://app.hydrawise.com/api/v1/customerdetails.php?'
+        m.get('https://api.hydrawise.com/api/v1/customerdetails.php?'
               'api_key={}'
               '&type={}'
               .format(GOOD_API_KEY, 'controllers'),
@@ -43,7 +43,7 @@ def test_customer_details():
         assert return_value is not None
 
         # Test an invalid api_key.
-        m.get('https://app.hydrawise.com/api/v1/customerdetails.php?'
+        m.get('https://api.hydrawise.com/api/v1/customerdetails.php?'
               'api_key={}'
               '&type={}'
               .format(BAD_API_KEY, 'controllers'),
@@ -67,7 +67,7 @@ def test_set_zones():
         error_string = '{"message": "not ok", "message_type": "error"}'
 
         # Test positive use of the stop command.
-        m.get('https://app.hydrawise.com/api/v1/setzone.php?'
+        m.get('https://api.hydrawise.com/api/v1/setzone.php?'
               'api_key={}'
               '&action={}'
               '&relay_id={}'
@@ -78,7 +78,7 @@ def test_set_zones():
         assert return_value is not None
 
         # Test negative use of the stop command.
-        m.get('https://app.hydrawise.com/api/v1/setzone.php?'
+        m.get('https://api.hydrawise.com/api/v1/setzone.php?'
               'api_key={}'
               '&action={}'
               .format(GOOD_API_KEY, 'stop'),
@@ -88,7 +88,7 @@ def test_set_zones():
         assert return_value is None
 
         # Test positive use of stopall.
-        m.get('https://app.hydrawise.com/api/v1/setzone.php?'
+        m.get('https://api.hydrawise.com/api/v1/setzone.php?'
               'api_key={}'
               '&action={}'
               .format(GOOD_API_KEY, 'stopall'),
@@ -98,7 +98,7 @@ def test_set_zones():
         assert return_value is not None
 
         # Test positive use of run.
-        m.get('https://app.hydrawise.com/api/v1/setzone.php?'
+        m.get('https://api.hydrawise.com/api/v1/setzone.php?'
               'api_key={}'
               '&action={}'
               '&relay_id={}'
@@ -118,7 +118,7 @@ def test_set_zones():
         assert return_value is None
 
         # Test positive use of runall.
-        m.get('https://app.hydrawise.com/api/v1/setzone.php?'
+        m.get('https://api.hydrawise.com/api/v1/setzone.php?'
               'api_key={}'
               '&action={}'
               '&period_id={}'
@@ -138,7 +138,7 @@ def test_set_zones():
         assert return_value is None
 
         # Test bad api_key.
-        m.get('https://app.hydrawise.com/api/v1/setzone.php?'
+        m.get('https://api.hydrawise.com/api/v1/setzone.php?'
               'api_key={}'
               '&action={}'
               '&period_id={}'


### PR DESCRIPTION
Might not be perfect from coding perspective (python beginner), but at least the consuming side can react on the error.
Also adjusted the API endpoint, according to the Hydrawise API docs it's https://api.* and not https://app.* although both are working (still).